### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-the grayscale of individual pixel data is analysed for the brightness and a char value is assigned to it, ' ' for rbg(0, 0, 0) and '$' for rbg(255, 255, 255)
-since all the pixels are mapped and converted to their char counterpart which taked up a lot more pixel as compared to a single pixel, the original image is to be scaled down to obtain legible ASCII counterpart
+the grayscale of individual pixel data is analysed for the brightness and a char value is assigned to it, ' ' for rgb(0, 0, 0) and '$' for rgb(255, 255, 255)
+since all the pixels are mapped and converted to their char counterpart which taken up a lot more pixel as compared to a single pixel, the original image is to be scaled down to obtain legible ASCII counterpart
 the font color is set according to the rgb of the pixel
 
-        ----IotA


### PR DESCRIPTION
## Summary
- fix RGB typo in README
- fix past-tense typo
- remove stray prompt line

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687de19b587c8328ad811fe9561c3b5c