### PR TITLE
Add text and HTML output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-the grayscale of individual pixel data is analysed for the brightness and a char value is assigned to it, ' ' for rgb(0, 0, 0) and '$' for rgb(255, 255, 255)
-since all the pixels are mapped and converted to their char counterpart which taken up a lot more pixel as compared to a single pixel, the original image is to be scaled down to obtain legible ASCII counterpart
-the font color is set according to the rgb of the pixel
+The grayscale of individual pixel data is analysed for the brightness and a
+char value is assigned to it, ' ' for rgb(0, 0, 0) and '$' for rgb(255, 255,
+255). Since all the pixels are mapped and converted to their char counterpart
+which taken up a lot more pixel as compared to a single pixel, the original
+image is to be scaled down to obtain legible ASCII counterpart. The font color
+is set according to the rgb of the pixel.
+
+## Usage
+
+```
+python ascii.py --format image  # default
+python ascii.py --format text   # write ASCII characters to a .txt file
+python ascii.py --format html   # write colored characters to a .html file
+```
 


### PR DESCRIPTION
## Summary
- add `output_format` parameter to generate image, plain text, or HTML ASCII art
- expose `--format` flag on CLI and document usage

## Testing
- `python -m py_compile ascii.py`
- `python ascii.py --format text`
- `python ascii.py --format html`


------
https://chatgpt.com/codex/tasks/task_e_68b00d42cbe48328acdcad330e9d8c03