### PR TITLE
Add ANSI color output mode

### DIFF
--- a/tests/test_ascii.py
+++ b/tests/test_ascii.py
@@ -19,6 +19,11 @@ def test_parse_args_defaults():
     assert args.output_dir == "./assets/output"
 
 
+def test_parse_args_ansi_format():
+    args = ascii_mod.parse_args(["--format", "ansi"])
+    assert args.format == "ansi"
+
+
 def test_convert_image_text_output(tmp_path):
     img = Image.new("RGB", (1, 1), color=(255, 255, 255))
     input_dir = Path("assets/input")
@@ -35,3 +40,24 @@ def test_convert_image_text_output(tmp_path):
     )
     out_file = tmp_path / f"O_h_0_f_1.0_{test_path.stem}.txt"
     assert out_file.exists()
+
+
+def test_convert_image_ansi_stdout(tmp_path, capsys):
+    img = Image.new("RGB", (1, 1), color=(255, 255, 255))
+    input_dir = Path("assets/input")
+    input_dir.mkdir(parents=True, exist_ok=True)
+    test_name = "test_ansi.png"
+    test_path = input_dir / test_name
+    img.save(test_path)
+    ascii_mod.convert_image(
+        test_path,
+        scale_factor=1.0,
+        bg_brightness=0,
+        output_dir=tmp_path,
+        output_format="ansi",
+    )
+    assert list(tmp_path.iterdir()) == []
+    captured = capsys.readouterr().out
+    expected_char = ascii_mod.get_char(255)
+    expected_line = f"\x1b[38;2;255;255;255m{expected_char}\x1b[0m"
+    assert expected_line in captured


### PR DESCRIPTION
## Summary
- add ANSI color mode to convert_image, printing colored ASCII to stdout
- include `ansi` in CLI `--format` choices
- expand tests for new ANSI mode

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b02310ee748328a5c7848fce74c18e