### PR TITLE
feat: allow custom font selection

### DIFF
--- a/tests/test_ascii.py
+++ b/tests/test_ascii.py
@@ -22,6 +22,7 @@ def test_parse_args_defaults():
     assert args.video is None
     assert args.webcam is False
     assert args.mono is False
+    assert args.font is None
 
 
 def test_parse_args_ansi_format():
@@ -44,6 +45,13 @@ def test_parse_args_webcam_flag():
 def test_parse_args_mono_flag():
     args = ascii_mod.parse_args(["--mono"])
     assert args.mono is True
+
+
+def test_parse_args_font_flag(tmp_path):
+    font_path = tmp_path / "fake.ttf"
+    font_path.touch()
+    args = ascii_mod.parse_args(["--font", str(font_path)])
+    assert args.font == str(font_path)
 
 
 def test_convert_image_text_output(tmp_path):


### PR DESCRIPTION
## Summary
- add `--font` CLI argument for custom TTF files
- use specified font for ASCII rendering and dynamic character generation
- test CLI defaults and font argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0452ff670832887253cd50044978b