### PR TITLE
Add GUI and expand image format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,62 @@
-the grayscale of individual pixel data is analysed for the brightness and a char value is assigned to it, ' ' for rgb(0, 0, 0) and '$' for rgb(255, 255, 255)
-since all the pixels are mapped and converted to their char counterpart which taken up a lot more pixel as compared to a single pixel, the original image is to be scaled down to obtain legible ASCII counterpart
-the font color is set according to the rgb of the pixel
+# ASCII Convert Script
 
+Convert images (PNG, JPG, GIF, BMP, etc.) into colorized ASCII art. Each pixel
+is mapped to a character whose "ink" coverage approximates the pixel
+brightness.
+
+## Installation
+
+```bash
+pip install pillow
+```
+
+## Command line usage
+
+```bash
+python ascii.py --input image.jpg --scale 0.2 --brightness 30
+```
+
+### Options
+
+- `--format {image,text,html}`: choose between PNG image output, plain text or
+  HTML with coloured spans.
+- `--batch <directory>`: convert every image in a directory.
+- `--dynamic-set`: build a brightness-ranked character set using
+  `computeUnicode.py`.
+
+If no `--input` is supplied the program will prompt for a file from
+`assets/input`.
+
+## Graphical interface
+
+A Tkinter based GUI is available for interactive conversions:
+
+```bash
+python gui.py
+```
+
+Use the **Browse** button to pick an image (any common format) and tweak the
+scale, brightness and output format. Converted images are previewed directly in
+the window when the image output mode is selected.
+
+## Generating custom character sets
+
+`computeUnicode.py` exposes `generate_char_array` which analyses each glyph of a
+font and sorts characters by coverage. The CLI `--dynamic-set` flag leverages
+this function automatically.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+## Contributing
+
+Issues and pull requests are welcome.
+
+## License
+
+MIT

--- a/computeUnicode.py
+++ b/computeUnicode.py
@@ -1,81 +1,82 @@
+"""Utilities for generating brightness-ranked character arrays.
+
+This module exposes ``generate_char_array`` which renders each character and
+computes how much of the glyph is "inked". The characters are then sorted from
+least filled (lightest) to most filled (darkest). The resulting array can be
+used to map grayscale values to characters in the ASCII art converter.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Iterable, List
+
 from PIL import Image, ImageDraw, ImageFont
 
-import os
-import sys
-import time
-import math
-
-baseArr = [' ', '!', '*', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', '0', '1', '2', '3', '4', '5',
-           '6', '7', '8', '9', ':', ';', '<', '=', '>', '?', '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
-           'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[', ']', '^', '_', '`',
-           'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-           'w', 'x', 'y', 'z', '{', '|', '}', '~', '¡', '¢', '£', '¤', '¥', '¦', '§', '¨', '©', 'ª', '«', '¬', '®', '¯',
-           '·', '¸', '¹', 'º', '»', '¼', '½', '¾', '¿', 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì',
-           'Í', 'Î', 'Ï', 'Ð', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', '×', 'Ø', 'Ù', 'Ú', 'Û', 'Ü', 'Ý', 'Þ', 'ß', 'à', 'á', 'â',
-           'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ð', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', '÷', 'ø',
-           'ù', 'ú', 'û', 'ü', 'ý', 'þ', 'ÿ', 'Ā', 'ā', 'Ă', 'ă', 'Ą', 'ą', 'Ć', 'ć', 'Ĉ', 'ĉ', 'Ċ', 'ċ', 'Č', 'č', 'Ď',
-           'ď', 'Đ', 'đ', 'Ē', 'ē', 'Ĕ', 'ĕ', 'Ė', 'ė', 'Ę', 'ę', 'Ě', 'ě', 'Ĝ', 'ĝ', 'Ğ', 'ğ', 'Ġ', 'ġ', 'Ģ', 'ģ', 'Ĥ',
-           'ĥ', 'Ħ', 'ħ', 'Ĩ', 'ĩ', 'Ī', 'ī', 'Ĭ', 'ĭ', 'Į', 'į', 'İ', 'ı', 'Ĳ', 'ĳ', 'Ĵ', 'ĵ', 'Ķ', 'ķ', 'ĸ', 'Ĺ', 'ĺ',
-           'Ļ', 'ļ', 'Ľ', 'ľ', 'Ŀ', 'ŀ', 'Ł', 'ł', 'Ń', 'ń', 'Ņ', 'ņ', 'Ň', 'ň', 'ŉ', 'Ŋ']
-
-percentageArr = []
-
-
-def compute_percentage(image):
-    width, height = image.size
-    pixels = image.load()
-    red, green, blue = 0, 0, 0
-    totalPixel = width * height
-    totalBlack = 0
-    totalWhite = 0
-
-    for i in range(height):
-        for j in range(width):
-            red, green, blue = pixels[j, i]
-            if compute_average(red, green, blue) > 100:
-                totalWhite += 1
-            else:
-                totalBlack += 1
-
-    return totalWhite / totalPixel
+# Base characters used to build the mapping. These are ordered arbitrarily and
+# will be sorted by brightness percentage.
+BASE_CHARS: List[str] = [
+    ' ', '!', '*', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', ';', '<', '=', '>', '?',
+    '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+    'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[', ']', '^', '_', '`',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+    'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '{', '|', '}', '~', '¡', '¢',
+    '£', '¤', '¥', '¦', '§', '¨', '©', 'ª', '«', '¬', '®', '¯', '·', '¸', '¹', 'º',
+    '»', '¼', '½', '¾', '¿', 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê',
+    'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ð', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', '×', 'Ø', 'Ù', 'Ú',
+    'Û', 'Ü', 'Ý', 'Þ', 'ß', 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê',
+    'ë', 'ì', 'í', 'î', 'ï', 'ð', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', '÷', 'ø', 'ù', 'ú',
+    'û', 'ü', 'ý', 'þ', 'ÿ', 'Ā', 'ā', 'Ă', 'ă', 'Ą', 'ą', 'Ć', 'ć', 'Ĉ', 'ĉ', 'Ċ',
+    'ċ', 'Č', 'č', 'Ď', 'ď', 'Đ', 'đ', 'Ē', 'ē', 'Ĕ', 'ĕ', 'Ė', 'ė', 'Ę', 'ę', 'Ě',
+    'ě', 'Ĝ', 'ĝ', 'Ğ', 'ğ', 'Ġ', 'ġ', 'Ģ', 'ģ', 'Ĥ', 'ĥ', 'Ħ', 'ħ', 'Ĩ', 'ĩ', 'Ī',
+    'ī', 'Ĭ', 'ĭ', 'Į', 'į', 'İ', 'ı', 'Ĳ', 'ĳ', 'Ĵ', 'ĵ', 'Ķ', 'ķ', 'ĸ', 'Ĺ', 'ĺ',
+    'Ļ', 'ļ', 'Ľ', 'ľ', 'Ŀ', 'ŀ', 'Ł', 'ł', 'Ń', 'ń', 'Ņ', 'ņ', 'Ň', 'ň', 'ŉ', 'Ŋ'
+]
 
 
-def construct_percentage_arr():
-    image_arr = []
-    count = 0
-    for i in baseArr:
-        font = ImageFont.truetype('C:\\Windows\\Fonts\\lucon.ttf', 250)
-
-        output_image = Image.new('RGB', (200, 250), color=(0, 0, 0))  # (0,0,0) for polychromatic images
-        draw_image = ImageDraw.Draw(output_image)
-
-        draw_image.text((25, 5), i, font=font, fill=(255, 255, 255))
-        # output_image.save(f"./test/image_{count}_.jpg")
-        count += 1
-
-        image_arr.append(output_image)
-
-    for image in image_arr:
-        percentageArr.append(compute_percentage(image))
-
-    # print(percentageArr)
-
-    sorted_char_array = [x for _, x in sorted(zip(percentageArr, baseArr))]
-
-    # percentage_arr = percentageArr.sort()
-    print(sorted_char_array)
-    print(percentageArr)
-
-    # output_image.save("./test/image{}.jpg".format(i))
+def _default_font_path() -> str:
+    """Return a monospaced font path available on the current system."""
+    windows_font = r"C:\\Windows\\Fonts\\lucon.ttf"
+    linux_font = "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf"
+    if os.path.exists(windows_font):
+        return windows_font
+    if os.path.exists(linux_font):
+        return linux_font
+    # Pillow's default bitmap font
+    return ""
 
 
-def compute_average(r, g, b):
-    return math.floor((r + g + b) / 3)
+def _ink_percentage(ch: str, font: ImageFont.FreeTypeFont) -> float:
+    """Return the ratio of white pixels for ``ch`` rendered with ``font``."""
+    canvas = Image.new('L', (200, 250), color=0)
+    draw = ImageDraw.Draw(canvas)
+    draw.text((25, 5), ch, font=font, fill=255)
+    width, height = canvas.size
+    pixels = canvas.load()
+    white = 0
+    for y in range(height):
+        for x in range(width):
+            if pixels[x, y] > 100:
+                white += 1
+    return white / float(width * height)
 
 
-# def construct_array() -> None:
-#     print(len(baseArr))
+def generate_char_array(font_path: str | None = None) -> List[str]:
+    """Return characters sorted by how much of the glyph is filled.
+
+    ``font_path`` may be supplied to point to a TTF font. When ``None`` the
+    function attempts to locate a system monospace font.
+    """
+    font_path = font_path or _default_font_path()
+    if font_path:
+        font = ImageFont.truetype(font_path, 250)
+    else:
+        font = ImageFont.load_default()
+    percentages = [_ink_percentage(ch, font) for ch in BASE_CHARS]
+    return [ch for _, ch in sorted(zip(percentages, BASE_CHARS))]
 
 
-# construct_array()
-construct_percentage_arr()
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    print(generate_char_array())

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,135 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from PIL import Image, ImageTk
+
+import ascii as ascii_mod
+
+
+def _default_output_dir():
+    return "./assets/output"
+
+
+class AsciiGui(tk.Tk):
+    """Simple Tkinter based interface for the ASCII converter."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("ASCII Converter")
+        self.geometry("600x400")
+
+        self.input_path = tk.StringVar()
+        self.scale = tk.DoubleVar(value=0.2)
+        self.brightness = tk.IntVar(value=30)
+        self.format_var = tk.StringVar(value="image")
+        self.dynamic_set = tk.BooleanVar()
+        self.output_dir = tk.StringVar(value=_default_output_dir())
+        self.preview = None
+
+        # Input file controls
+        tk.Label(self, text="Input image:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        tk.Entry(self, textvariable=self.input_path, width=40).grid(
+            row=0, column=1, padx=5, pady=5, sticky="we"
+        )
+        tk.Button(self, text="Browse", command=self.browse).grid(
+            row=0, column=2, padx=5, pady=5
+        )
+
+        # Scale slider
+        tk.Label(self, text="Scale:").grid(row=1, column=0, sticky="w", padx=5)
+        tk.Scale(
+            self,
+            from_=0.05,
+            to=1.0,
+            resolution=0.05,
+            orient=tk.HORIZONTAL,
+            variable=self.scale,
+        ).grid(row=1, column=1, columnspan=2, sticky="we", padx=5)
+
+        # Brightness slider
+        tk.Label(self, text="Brightness:").grid(row=2, column=0, sticky="w", padx=5)
+        tk.Scale(
+            self,
+            from_=0,
+            to=255,
+            orient=tk.HORIZONTAL,
+            variable=self.brightness,
+        ).grid(row=2, column=1, columnspan=2, sticky="we", padx=5)
+
+        # Output format
+        tk.Label(self, text="Format:").grid(row=3, column=0, sticky="w", padx=5)
+        tk.OptionMenu(
+            self, self.format_var, "image", "text", "html"
+        ).grid(row=3, column=1, sticky="w", padx=5)
+
+        # Dynamic set checkbox
+        tk.Checkbutton(
+            self, text="Dynamic character set", variable=self.dynamic_set
+        ).grid(row=4, column=0, columnspan=2, sticky="w", padx=5)
+
+        # Output directory entry
+        tk.Label(self, text="Output dir:").grid(row=5, column=0, sticky="w", padx=5)
+        tk.Entry(self, textvariable=self.output_dir, width=40).grid(
+            row=5, column=1, padx=5, pady=5, sticky="we"
+        )
+        tk.Button(self, text="Browse", command=self.browse_output).grid(
+            row=5, column=2, padx=5, pady=5
+        )
+
+        # Convert button
+        tk.Button(self, text="Convert", command=self.convert).grid(
+            row=6, column=0, columnspan=3, pady=10
+        )
+
+        # Preview label
+        self.preview_label = tk.Label(self)
+        self.preview_label.grid(row=7, column=0, columnspan=3, pady=5)
+
+        self.columnconfigure(1, weight=1)
+
+    def browse(self):
+        filetypes = [
+            ("Image files", "*.png *.jpg *.jpeg *.bmp *.gif *.tiff"),
+            ("All files", "*.*"),
+        ]
+        filename = filedialog.askopenfilename(filetypes=filetypes)
+        if filename:
+            self.input_path.set(filename)
+
+    def browse_output(self):
+        directory = filedialog.askdirectory()
+        if directory:
+            self.output_dir.set(directory)
+
+    def convert(self):
+        if not self.input_path.get():
+            messagebox.showerror("Error", "Please select an image file")
+            return
+
+        ascii_mod.load_char_array(dynamic=self.dynamic_set.get())
+        out_paths = ascii_mod.convert_image(
+            self.input_path.get(),
+            scale_factor=self.scale.get(),
+            bg_brightness=self.brightness.get(),
+            output_dir=self.output_dir.get(),
+            output_format=self.format_var.get(),
+        )
+        if not out_paths:
+            messagebox.showerror("Error", "Conversion failed")
+            return
+
+        if self.format_var.get() == "image":
+            img = Image.open(out_paths[0])
+            self.preview = ImageTk.PhotoImage(img)
+            self.preview_label.configure(image=self.preview)
+        else:
+            self.preview_label.configure(text="Conversion complete")
+        messagebox.showinfo("Success", f"Saved to {', '.join(out_paths)}")
+
+
+def main():
+    app = AsciiGui()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ascii.py
+++ b/tests/test_ascii.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+
+from PIL import Image
+
+import ascii as ascii_mod
+
+
+def test_get_char_range():
+    assert ascii_mod.get_char(0) == ascii_mod.char_array[0]
+    assert ascii_mod.get_char(255) == ascii_mod.char_array[-1]
+
+
+def test_parse_args_defaults():
+    args = ascii_mod.parse_args([])
+    assert args.input is None
+    assert args.scale is None
+    assert args.brightness is None
+    assert args.output_dir == "./assets/output"
+
+
+def test_convert_image_text_output(tmp_path):
+    img = Image.new("RGB", (1, 1), color=(255, 255, 255))
+    input_dir = Path("assets/input")
+    input_dir.mkdir(parents=True, exist_ok=True)
+    test_name = "test.png"
+    test_path = input_dir / test_name
+    img.save(test_path)
+    ascii_mod.convert_image(
+        test_path,
+        scale_factor=1.0,
+        bg_brightness=0,
+        output_dir=tmp_path,
+        output_format="text",
+    )
+    out_file = tmp_path / f"O_h_0_f_1.0_{test_path.stem}.txt"
+    assert out_file.exists()
+
+
+def test_convert_image_bmp_output(tmp_path):
+    img = Image.new("RGB", (1, 1), color=(255, 0, 0))
+    input_dir = Path("assets/input")
+    input_dir.mkdir(parents=True, exist_ok=True)
+    test_name = "test.bmp"
+    test_path = input_dir / test_name
+    img.save(test_path)
+    paths = ascii_mod.convert_image(
+        test_path,
+        scale_factor=1.0,
+        bg_brightness=0,
+        output_dir=tmp_path,
+        output_format="image",
+    )
+    out_file = tmp_path / f"O_h_0_f_1.0_{test_path.stem}.png"
+    assert out_file.exists()
+    assert str(out_file) in paths


### PR DESCRIPTION
## Summary
- support multiple image formats and return generated paths
- add Tkinter-based GUI with image preview and configuration controls
- document GUI usage and broaden file type support in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afff403e308328a7328544d31e8b6b