### PR TITLE
Persist GUI settings to config file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+  "input_path": null,
+  "scale": 0.2,
+  "brightness": 30,
+  "format": "image",
+  "dynamic_set": false,
+  "output_dir": "./assets/output"
+}


### PR DESCRIPTION
## Summary
- remember GUI settings between runs by loading and saving `config.json`
- add controls for dynamic character set and output directory
- provide a "Reset to defaults" option and persist preferences on shutdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1710e7f6c8328a0c28fd14bf1ce6d