### PR TITLE
Add font selection to ASCII converter GUI

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
   "brightness": 30,
   "format": "image",
   "dynamic_set": false,
-  "output_dir": "./assets/output"
+  "output_dir": "./assets/output",
+  "font_path": null
 }


### PR DESCRIPTION
## Summary
- Allow users to choose a TTF font for rendering via new *Font...* button
- Pass selected font to `load_char_array` and `convert_image` and show font name in GUI
- Persist chosen font path in configuration

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b172f70ec08328a91c0b96366271c0