### PR TITLE
feat(gui): support batch conversion

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "input_path": null,
+  "input_paths": [],
   "scale": 0.2,
   "brightness": 30,
   "format": "image",


### PR DESCRIPTION
## Summary
- allow selecting multiple input files via listbox with Add/Remove controls
- convert all queued files with progress and optional preview of the first result
- persist multiple input paths in config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b173aeafe083289446ddbc23383b61