### PR TITLE
feat: add theme selection

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,6 @@
   "format": "image",
   "dynamic_set": false,
   "output_dir": "./assets/output",
-  "font_path": null
+  "font_path": null,
+  "theme": "light"
 }


### PR DESCRIPTION
## Summary
- add light and dark theme options with menu selection
- persist user theme choice in config file
- apply themed colors across widgets using `ttk.Style`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b174f4177c8328a556ef18bb508f9c